### PR TITLE
gcc, binutils: link to Cellar instead of system libs

### DIFF
--- a/Library/Formula/binutils.rb
+++ b/Library/Formula/binutils.rb
@@ -26,6 +26,7 @@ class Binutils < Formula
                           "--disable-werror",
                           "--enable-interwork",
                           "--enable-multilib",
+                          ("--with-lib-path=#{HOMEBREW_PREFIX}/lib" if OS.linux?),
                           "--enable-64-bit-bfd",
                           "--enable-targets=all"
     system "make"

--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -166,6 +166,12 @@ class Gcc < Formula
         args << "--with-sysroot=#{MacOS.sdk_path}"
       end
 
+      if OS.linux?
+        @link = Pathname.new "#{prefix}/x86_64-unknown-linux-gnu/bin"
+        @link.parent.mkpath
+        @link.make_symlink "#{HOMEBREW_PREFIX}/lib"
+      end
+
       system "../configure", *args
       system "make", "bootstrap"
       system "make", "install"
@@ -210,6 +216,17 @@ class Gcc < Formula
       rmdir lib64
       prefix.install_symlink "lib" => "lib64"
     end
+    
+    if OS.linux?
+      p = @link.parent
+      @link.delete
+      p.delete
+      crts = Pathname.new "#{lib}/gcc/x86_64-unknown-linux-gnu/#{version}"
+      Formula['glibc'].lib.children.select {|p| p.basename.to_s =~ /^crt.\.o$/ }.collect {|p| p.relative_path_from crts}.each do |p|
+        crts.install_symlink p 
+      end
+    end
+
   end
 
   def add_suffix file, suffix


### PR DESCRIPTION
Symlinks `linuxbrew/lib` to Cellar for `gcc`, where `gcc` will automatically look because that is the prefix. Should fix the issue discussed recently in #107.