### PR TITLE
procps: Don't update ldconfig cache

### DIFF
--- a/Library/Formula/procps.rb
+++ b/Library/Formula/procps.rb
@@ -19,6 +19,7 @@ class Procps < Formula
     system "make", "install",
       "SKIP=$(bin)kill $(man1)kill.1 $(bin)uptime $(man1)uptime.1",
       "install=install -D",
+      "ldconfig=ldconfig -N",
       "usr/bin=#{bin}/",
       "bin=#{bin}/",
       "sbin=#{sbin}/",


### PR DESCRIPTION
The dynamic library cache is owned by root and attempting to update it
as a regular user will cause the formula to fail.