### PR TITLE
glibc: enable obsolete rpc

### DIFF
--- a/Library/Formula/glibc.rb
+++ b/Library/Formula/glibc.rb
@@ -16,6 +16,7 @@ class Glibc < Formula
         "--disable-debug",
         "--disable-dependency-tracking",
         "--disable-silent-rules",
+        "--enable-obsolete-rpc",
         "--prefix=#{prefix}",
         "--without-selinux"] # Fix error: selinux/selinux.h: No such file or directory
       args << "--with-binutils=" +


### PR DESCRIPTION
Necessary to compile libvirt.