### PR TITLE
rtorrent: requires curl installed

### DIFF
--- a/Library/Formula/rtorrent.rb
+++ b/Library/Formula/rtorrent.rb
@@ -11,6 +11,7 @@ class Rtorrent < Formula
   depends_on "cppunit" => :build
   depends_on "libtorrent"
   depends_on "xmlrpc-c" => :optional
+  depends_on "curl" => :build
 
   # https://github.com/Homebrew/homebrew/issues/24132
   fails_with :clang do

--- a/Library/Formula/rtorrent.rb
+++ b/Library/Formula/rtorrent.rb
@@ -11,7 +11,7 @@ class Rtorrent < Formula
   depends_on "cppunit" => :build
   depends_on "libtorrent"
   depends_on "xmlrpc-c" => :optional
-  depends_on "curl" => :build
+  depends_on "curl" => :build unless OS.mac?
 
   # https://github.com/Homebrew/homebrew/issues/24132
   fails_with :clang do


### PR DESCRIPTION
curl is a must for rtorrent installation => added as dependency