### PR TITLE
rtags: fix on linux - adjust for libc++abi only when on OS/X

### DIFF
--- a/Library/Formula/rtags.rb
+++ b/Library/Formula/rtags.rb
@@ -19,7 +19,7 @@ class Rtags < Formula
 
   def install
     # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi
-    ENV.append("LDFLAGS", "-lc++abi")
+    ENV.append("LDFLAGS", "-lc++abi") if OS.mac?
 
     mkdir "build" do
       system "cmake", "..", *std_cmake_args


### PR DESCRIPTION
The adjustment ```ENV.append("LDFLAGS", "-lc++abi")``` is necessary only on OSX, _not_ linux, where it will generate an error.
The fix is to execute that statement conditionally,
```
    # Homebrew llvm libc++.dylib doesn't correctly reexport libc++abi
    ENV.append("LDFLAGS", "-lc++abi") if OS.mac?
```