### PR TITLE
openssl: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -66,7 +66,7 @@ class Openssl < Formula
     # https://langui.sh/2015/11/27/sip-and-dlopen
     inreplace "crypto/comp/c_zlib.c",
               'zlib_dso = DSO_load(NULL, "z", NULL, 0);',
-              'zlib_dso = DSO_load(NULL, "/usr/lib/libz.dylib", NULL, DSO_FLAG_NO_NAME_TRANSLATION);'
+              'zlib_dso = DSO_load(NULL, "/usr/lib/libz.dylib", NULL, DSO_FLAG_NO_NAME_TRANSLATION);' if OS.mac?
 
     if build.universal?
       ENV.permit_arch_flags


### PR DESCRIPTION
Fix the error
/usr/lib/libz.dylib: cannot open shared object file: No such file or directory