### PR TITLE
bin/brew: fix stat on linux

### DIFF
--- a/bin/brew
+++ b/bin/brew
@@ -137,7 +137,7 @@ fi
 HOMEBREW_COMMAND="$1"
 HOMEBREW_BASH_COMMAND="$HOMEBREW_LIBRARY/Homebrew/cmd/$1.sh"
 
-if [[ "$(id -u)" = "0" && "$(stat -f%u "$HOMEBREW_BREW_FILE")" != "0" ]]
+if [[ "$(id -u)" = "0" && "$(stat -c%u "$HOMEBREW_BREW_FILE")" != "0" ]]
 then
   case "$HOMEBREW_COMMAND" in
     instal|install|reinstall|postinstall|ln|link|pin|update|update-bash|upgrade|create|migrate|tap|switch)


### PR DESCRIPTION
This PR fixes the following error:

```
$ sudo brew
stat: invalid option -- '%'
Try 'stat --help' for more information.
```

`stat` in GNU coreutils uses `-c` for format, where BSD `stat` uses `-f`.
