### PR TITLE
Fix libffi: make universal binary for OS X only

### DIFF
--- a/Library/Formula/libffi.rb
+++ b/Library/Formula/libffi.rb
@@ -34,8 +34,8 @@ class Libffi < Formula
     # Move lib64/* to lib/ on Linuxbrew
     lib64 = Pathname.new "#{lib}64"
     if lib64.directory?
-      system "mv #{lib64}/* #{lib}/"
-      rmdir lib64
+      mv Dir.glob('#{lib64}/*'), '#{lib}'
+      rmdir '#{lib64}'
     end
   end
 

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -294,6 +294,7 @@ module Stdenv
   end
 
   def universal_binary
+    return unless OS.mac?
     check_for_compiler_universal_support
 
     append_to_cflags Hardware::CPU.universal_archs.as_arch_flags


### PR DESCRIPTION
Without this fix, building libffi from source fails on Linux with an error message: "Error: Non-Apple GCC can't build universal binaries"