### PR TITLE
nspr: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/nspr.rb
+++ b/Library/Formula/nspr.rb
@@ -37,7 +37,7 @@ class Nspr < Formula
       args << "--enable-64bit" if MacOS.prefer_64_bit?
       system "./configure", *args
       # Remove the broken (for anyone but Firefox) install_name
-      inreplace "config/autoconf.mk", "-install_name @executable_path/$@ ", "-install_name #{lib}/$@ "
+      inreplace "config/autoconf.mk", "-install_name @executable_path/$@ ", "-install_name #{lib}/$@ " if OS.mac?
 
       system "make"
       system "make", "install"


### PR DESCRIPTION
Note that this *might* be susceptible to the issue described at https://github.com/Homebrew/homebrew/issues/3041 . It's impossible to tell, since neither spidermonkey nor couchdb install at the moment.