### PR TITLE
Revert "mcrypt 2.6.8: Fix for Linuxbrew"

### DIFF
--- a/Library/Formula/mcrypt.rb
+++ b/Library/Formula/mcrypt.rb
@@ -28,9 +28,6 @@ class Mcrypt < Formula
   def install
     ENV.universal_binary if build.universal?
 
-    # Fix configure: error: *** libmcrypt was not found
-    ENV["LD_LIBRARY_PATH"] = lib unless OS.mac?
-
     resource("libmcrypt").stage do
       system "./configure", "--prefix=#{prefix}",
                             "--mandir=#{man}"

--- a/Library/Homebrew/extend/ENV/std.rb
+++ b/Library/Homebrew/extend/ENV/std.rb
@@ -56,6 +56,9 @@ module Stdenv
 
     append "LDFLAGS", "-Wl,-headerpad_max_install_names" if OS.mac?
 
+    # Add this formula's library directory to the shared library search path.
+    prepend "LD_LIBRARY_PATH", formula.lib, File::PATH_SEPARATOR if formula && OS.linux?
+
     if OS.linux? && !["glibc", "glibc25"].include?(formula && formula.name)
       # Set the dynamic linker
       glibc = Formula["glibc"] rescue nil


### PR DESCRIPTION
This reverts commit 794d8052fca6e65142c4cfafec33728e4f72573e.
This fix is no longer necessary. It's been moved to core.