### PR TITLE
openssl: add with-ssl2 option

### DIFF
--- a/Library/Formula/openssl.rb
+++ b/Library/Formula/openssl.rb
@@ -60,7 +60,7 @@ class Openssl < Formula
   def configure_args; %W[
     --prefix=#{prefix}
     --openssldir=#{openssldir}
-    no-ssl2
+    #{"no-ssl2" if build.without?("ssl2")}
     zlib-dynamic
     shared
     enable-cms


### PR DESCRIPTION
Provide an option to build openssl with ssl2 support if there is a need for one.