### PR TITLE
glibc: fix for chmod in postinstall

### DIFF
--- a/Library/Formula/glibc.rb
+++ b/Library/Formula/glibc.rb
@@ -36,7 +36,7 @@ class Glibc < Formula
 
   def post_install
     # Fix permissions
-    chmod "+x", [lib/"ld-#{version}.so", lib/"libc-#{version}.so"]
+    chmod 0755, [lib/"ld-#{version}.so", lib/"libc-#{version}.so"]
 
     # Compile locale definition files
     mkdir_p lib/"locale"


### PR DESCRIPTION
When I try to use current glibc formula, it fails with the following error message: 
```
$ brew postinstall glibc
Error: can't convert String into Integer
```