### PR TITLE
fixes for coreutils and wget

### DIFF
--- a/Library/Formula/coreutils.rb
+++ b/Library/Formula/coreutils.rb
@@ -29,6 +29,7 @@ class Coreutils < Formula
     depends_on "texinfo" => :build
     depends_on "xz" => :build
     depends_on "wget" => :build
+    depends_on "homebrew/dupes/gperf" => :build unless OS.mac?
   end
 
   depends_on "gmp" => :optional

--- a/Library/Formula/coreutils.rb
+++ b/Library/Formula/coreutils.rb
@@ -20,7 +20,7 @@ class Coreutils < Formula
   conflicts_with "aardvark_shell_utils", :because => "both install `realpath` binaries"
 
   head do
-    url "git://git.sv.gnu.org/coreutils"
+    url "http://git.savannah.gnu.org/r/coreutils.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build


### PR DESCRIPTION
**`coreutils`**:
1. Changed the url used for building a HEAD version. Current one seems to be valid but non-functional. 
2. Added `gperf` as a dependency because it is required during the bootstrapping phase

**`wget`**:
1. Change dependency on `util-linux` to `libuuid` because `wget` is a build-dependency of `coreutils` which has minor conflict with `util-linux`.