### PR TITLE
subversion and libssh: add missing krb5 build dependency

### DIFF
--- a/Library/Formula/coreutils.rb
+++ b/Library/Formula/coreutils.rb
@@ -29,6 +29,7 @@ class Coreutils < Formula
     depends_on "texinfo" => :build
     depends_on "xz" => :build
     depends_on "wget" => :build
+    depends_on "homebrew/dupes/gperf" => :build unless OS.mac?
   end
 
   depends_on "gmp" => :optional

--- a/Library/Formula/coreutils.rb
+++ b/Library/Formula/coreutils.rb
@@ -20,7 +20,7 @@ class Coreutils < Formula
   conflicts_with "aardvark_shell_utils", :because => "both install `realpath` binaries"
 
   head do
-    url "git://git.sv.gnu.org/coreutils"
+    url "http://git.savannah.gnu.org/r/coreutils.git"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Library/Formula/libssh.rb
+++ b/Library/Formula/libssh.rb
@@ -14,6 +14,7 @@ class Libssh < Formula
 
   depends_on "cmake" => :build
   depends_on "openssl"
+  depends_on "krb5" => :build unless OS.mac?
 
   def install
     mkdir "build" do

--- a/Library/Formula/subversion.rb
+++ b/Library/Formula/subversion.rb
@@ -30,6 +30,7 @@ class Subversion < Formula
 
   depends_on "pkg-config" => :build
   depends_on :apr => :build
+  depends_on "krb5" => :build unless OS.mac?
 
   # Always build against Homebrew versions instead of system versions for consistency.
   depends_on "sqlite"


### PR DESCRIPTION
Standalone linux installation.
When building `subversion` and `libssh` from source, both complain about missing `gssapi/gssapi.h` file:

**Subversion:**
```
[linuxbrew-folder]/bin/gcc-5 -o auth/auth_spnego_gss.o -c -Os -w -pipe -march=core2 -std=c89 -Wdeclaration-after-statement -Wmissing-prototypes -Wall -O2 -pthread -DNDEBUG -DLINUX -D_REENTRANT -D_GNU_SOURCE -DSERF_HAVE_GSSAPI -I. -I[linuxbrew-folder]/Cellar/apr/1.5.2/libexec/include/apr-1 -I[linuxbrew-folder]/Cellar/apr-util/1.5.4_1/libexec/include/apr-1 -I[linuxbrew-folder]/opt/openssl/include auth/auth_spnego_gss.c
auth/auth_spnego_gss.c:22:27: fatal error: gssapi/gssapi.h: No such file or directory
compilation terminated.
scons: *** [auth/auth_spnego_gss.o] Error 1
scons: building terminated because of errors.
```

**Libssh:**
```
/tmp/libssh20160224-15635-9lh8wl/libssh-0.7.2/src/gssapi.c:30:27: fatal error: gssapi/gssapi.h: No such file or directory                                                                                                              
compilation terminated.                                                                                                                                                                                                                
make[2]: *** [src/CMakeFiles/ssh_shared.dir/gssapi.c.o] Error 1                                                                                                                                                                        
make[2]: *** Waiting for unfinished jobs....                                                                                                                                                                                           
make[2]: Leaving directory `/tmp/libssh20160224-15635-9lh8wl/libssh-0.7.2/build'                                                                                                                                                       
make[1]: *** [src/CMakeFiles/ssh_shared.dir/all] Error 2                                                                                                                                                                               
make[1]: Leaving directory `/tmp/libssh20160224-15635-9lh8wl/libssh-0.7.2/build'                                                                                                                                                       
make: *** [all] Error
```
(By the by, `libssh` has 0.7.3 now)

This file is in `/usr/include/gssapi/gssapi.h`, but standalone installation does not know about it.
Package `krb5` provides us with this file, hence the PR.

P.S. building `subversion` still fails but with a different error `/usr/bin/ld: unrecognized option '-plugin'`
Not sure why `/usr/bin/ld` is called...
```
[linuxbrew-folder]/bin/gcc-5 -o libserf-1.so.1.3.0 -L[linuxbrew-folder]/lib -Wl,--dynamic-linker=[linuxbrew-folder]/lib/ld.so -Wl,-rpath,[linuxbrew-folder]/lib -pthread -shared -Wl,-Bsymbolic -Wl,-soname=libserf-1.so.1 -Wl,-rpath=[linuxbrew-folder]/Cellar/subversion/1.9.3/lib -Wl,-rpath=:[linuxbrew-folder]/Cellar/apr/1.5.2/libexec/lib -Wl,-rpath=:[linuxbrew-folder]/Cellar/apr-util/1.5.4_1/libexec/lib -Wl,-rpath=:[linuxbrew-folder]/opt/openssl/lib context.os incoming.os outgoing.os ssltunnel.os buckets/aggregate_buckets.os buckets/allocator.os buckets/barrier_buckets.os buckets/buckets.os buckets/bwtp_buckets.os buckets/chunk_buckets.os buckets/dechunk_buckets.os buckets/deflate_buckets.os buckets/file_buckets.os buckets/headers_buckets.os buckets/iovec_buckets.os buckets/limit_buckets.os buckets/mmap_buckets.os buckets/request_buckets.os buckets/response_body_buckets.os buckets/response_buckets.os buckets/simple_buckets.os buckets/socket_buckets.os buckets/ssl_buckets.os auth/auth.os auth/auth_basic.os auth/auth_digest.os auth/auth_spnego.os auth/auth_spnego_gss.os auth/auth_spnego_sspi.os -L[linuxbrew-folder]/Cellar/apr/1.5.2/libexec/lib -L[linuxbrew-folder]/Cellar/apr-util/1.5.4_1/libexec/lib -L[linuxbrew-folder]/opt/openssl/lib -lssl -lcrypto -lz -lapr-1 -luuid -lrt -lcrypt -lpthread -ldl -laprutil-1 -lexpat -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err
/usr/bin/ld: unrecognized option '-plugin'
/usr/bin/ld: use the --help option for usage information
collect2: error: ld returned 1 exit status
scons: *** [libserf-1.so.1.3.0] Error 1
scons: building terminated because of errors.
```