### PR TITLE
rust: Fix Rust 1.6.0 build

### DIFF
--- a/Library/Formula/rust.rb
+++ b/Library/Formula/rust.rb
@@ -86,10 +86,6 @@ class Rust < Formula
       end
 
       system "./configure", "--prefix=#{prefix}", "--local-rust-root=#{prefix}", "--enable-optimize"
-      
-      # Snapshots.txt for 1.6.0 are NOT compatible with crates.io
-      system 
-      
       system "make"
       system "make", "install"
     end

--- a/Library/Homebrew/cmd/install.rb
+++ b/Library/Homebrew/cmd/install.rb
@@ -195,8 +195,7 @@ module Homebrew
     ld_so = HOMEBREW_PREFIX/"lib/ld.so"
     return if ld_so.readable?
     glibc = Formula["glibc"]
-    interpreter = glibc && glibc.installed? ? glibc.lib/"ld-linux-x86-64.so.2"
-      : "/lib64/ld-linux-x86-64.so.2"
+    interpreter = glibc && glibc.installed? ? glibc.lib/"ld-linux-x86-64.so.2" : "/lib64/ld-linux-x86-64.so.2"
     mkdir_p HOMEBREW_PREFIX/"lib"
     FileUtils.ln_sf interpreter, ld_so
   rescue FormulaUnavailableError


### PR DESCRIPTION
Fix bootstraping of Cargo by using a newer snapshot of Cargo compatible with the current version of crates.io