### PR TITLE
cmake: Depends on bzip2

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -3,6 +3,7 @@ class Cmake < Formula
   homepage "https://www.cmake.org/"
   url "https://cmake.org/files/v3.4/cmake-3.4.3.tar.gz"
   sha256 "b73f8c1029611df7ed81796bf5ca8ba0ef41c6761132340c73ffe42704f980fa"
+  revision 1
   head "https://cmake.org/cmake.git"
 
   bottle do
@@ -18,6 +19,7 @@ class Cmake < Formula
 
   depends_on "sphinx-doc" => :build if build.with? "docs"
   depends_on "curl" unless OS.mac?
+  depends_on "bzip2" unless OS.mac?
 
   # The `with-qt` GUI option was removed due to circular dependencies if
   # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
    - Build doesn't fail because it downloads bottle
    - Build from source takes FOREVER for CMake. I'll try to upload a log in the morning
- [X] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [ ] Have you built your formula locally prior to submission with `brew install <formula>`?
  - I'll try overnight. Problems may persist with other dependency issues. Specifically the default Sphinx dependency is a real PITA
