### PR TITLE
ganglia: explicitly specify path to apr

### DIFF
--- a/Library/Formula/ganglia.rb
+++ b/Library/Formula/ganglia.rb
@@ -42,7 +42,9 @@ class Ganglia < Formula
                           "--sysconfdir=#{etc}",
                           "--mandir=#{man}",
                           "--with-gmetad",
-                          "--with-libpcre=#{Formula["pcre"].opt_prefix}"
+                          "--with-libpcre=#{Formula["pcre"].opt_prefix}",
+                          "--with-libapr=#{Formula["apr"].opt_prefix}/bin/apr-1-config"
+
     system "make", "install"
 
     # Generate the default config file


### PR DESCRIPTION
Ganglia could not find apr library by default on CentOS 6.7

- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
