### PR TITLE
qcachegrind: Fix build for Linux

### DIFF
--- a/Library/Formula/qcachegrind.rb
+++ b/Library/Formula/qcachegrind.rb
@@ -16,12 +16,18 @@ class Qcachegrind < Formula
   depends_on "qt"
 
   def install
-    cd "qcachegrind"
-    system "qmake", "-spec", "macx-g++", "-config", "release"
-    system "make"
-    # Install app
-    prefix.install "qcachegrind.app"
-    # Symlink in the command-line version
-    bin.install_symlink prefix/"qcachegrind.app/Contents/MacOS/qcachegrind"
+    if OS.mac?
+      cd "qcachegrind"
+      system "qmake", "-spec", "macx-g++", "-config", "release"
+      system "make"
+      # Install app
+      prefix.install "qcachegrind.app"
+      # Symlink in the command-line version
+      bin.install_symlink prefix/"qcachegrind.app/Contents/MacOS/qcachegrind"
+    else
+      system "qmake", "-config", "release"
+      system "make"
+      bin.install "qcachegrind/qcachegrind"
+    end
   end
 end


### PR DESCRIPTION
Closes #852.

See https://gist.github.com/rwhogg/f6d505a1a8712c4be9b9

Message:
> g++: error: unrecognized command line option '-h'
Makefile:224: recipe for target 'qcachegrind.app/Contents/MacOS/qcachegrind' failed
make: *** [qcachegrind.app/Contents/MacOS/qcachegrind] Error 1

Note that there is currently no test for this formula, but IMO that should be fixed upstream first and then patched for Linux as appropriate.