### PR TITLE
gnu-tar: Avoid patch on linux

### DIFF
--- a/Library/Formula/gnu-tar.rb
+++ b/Library/Formula/gnu-tar.rb
@@ -19,7 +19,7 @@ class GnuTar < Formula
   patch do
     url "https://gist.githubusercontent.com/mistydemeo/10fbae8b8441359ba86d/raw/e5c183b72036821856f9e82b46fba6185e10e8b9/gnutar-configure-xattrs.patch"
     sha256 "f2e56bb8afd1c641a7e5b81e35fdbf36b6fb66434b1e35caa8b55196b30c3ad9"
-  end
+  end if OS.mac?
 
   def install
     # Work around unremovable, nested dirs bug that affects lots of


### PR DESCRIPTION
The patch includes changes to `Makefile.in`. Therefore the `./configure` script realizes that the file has changed and needs to regenerate `Makefile`, which hence requires the autotools suite. However, the autotools suite has set the `am__api_version` to be 1.14, while the newest brew version is 1.15. Since the configure script explicitly requires the versioned `automake-1.14` binary, this doesn't compile with brew autotools. 

Obviously this can be circumvented if we don't patch, but I'm not sure if this is the best way to fix this problem. The alternative would be to require autotools for build, and run `autoreconf -fi` before configure, but this may be considered heavy handed. It would be great if there were some way to link the usage of autotools if certain files were patched.