### PR TITLE
wxmac: fix build for linux

### DIFF
--- a/Library/Formula/wxmac.rb
+++ b/Library/Formula/wxmac.rb
@@ -19,6 +19,7 @@ class Wxmac < Formula
   depends_on "jpeg"
   depends_on "libpng"
   depends_on "libtiff"
+  depends_on "gtk+" unless OS.mac?
 
   # Various fixes related to Yosemite. Revisit in next stable release.
   # Please keep an eye on http://trac.wxwidgets.org/ticket/16329 as well
@@ -34,7 +35,6 @@ class Wxmac < Formula
       "--enable-std_string",
       "--enable-display",
       "--with-opengl",
-      "--with-osx_cocoa",
       "--with-libjpeg",
       "--with-libtiff",
       # Otherwise, even in superenv, the internal libtiff can pick
@@ -56,10 +56,14 @@ class Wxmac < Formula
       "--enable-dataviewctrl",
       "--with-expat",
       "--disable-precomp-headers",
-      "--with-macosx-version-min=#{MacOS.version}",
       # This is the default option, but be explicit
       "--disable-monolithic",
     ]
+
+    if OS.mac?
+      args << "--with-osx_cocoa"
+      args << "--with-macosx-version-min=#{MacOS.version}"
+    end
 
     if build.universal?
       ENV.universal_binary


### PR DESCRIPTION
See https://gist.github.com/rwhogg/33906c99f0335a9d6705

Closes #512

Message:
> checking if C compiler (/home/bob/.linuxbrew/bin/gcc-5 -mmacosx-version-min=0) works with SDK/version options... configure: error: in `/home/bob/tmp/wxmac20160227-6760-1wyythr/wxWidgets-3.0.2':
configure: error: no.  Try a different SDK
See `config.log' for more details

