### PR TITLE
Make caddy build on linux

### DIFF
--- a/Library/Formula/caddy.rb
+++ b/Library/Formula/caddy.rb
@@ -88,7 +88,7 @@ class Caddy < Formula
 
   def install
     ENV["GOPATH"] = buildpath
-    ENV["GOOS"] = "darwin"
+    ENV["GOOS"] = OS::NAME
     ENV["GOARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386"
 
     mkdir_p buildpath/"src/github.com/mholt/"


### PR DESCRIPTION
Set the os using the OS::NAME constant.

I have another pull request that bunchs a bunch of apps together, which is sloppy.

This incorporates the suggestions and only deals with caddy.

### All Submissions:

_You can erase any parts of this template not applicable to your Pull Request._

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

