### PR TITLE
gcc: Add brew env LDFLAGS to boot-ldflags on non-standalone

### DIFF
--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -118,7 +118,6 @@ class Gcc < Formula
         "--with-native-system-header-dir=#{HOMEBREW_PREFIX}/include",
         "--with-local-prefix=#{HOMEBREW_PREFIX}/local",
         "--with-build-time-tools=#{binutils}",
-        "--with-boot-ldflags=-static-libstdc++ -static-libgcc #{ENV["LDFLAGS"]}",
       ]
       # Set the search path for glibc libraries and objects.
       ENV["LIBRARY_PATH"] = Formula["glibc"].lib
@@ -126,6 +125,7 @@ class Gcc < Formula
     args += [
       "--prefix=#{prefix}",
       ("--libdir=#{lib}/gcc/#{version_suffix}" if OS.mac?),
+      "--with-boot-ldflags=-static-libstdc++ -static-libgcc #{ENV["LDFLAGS"]}",
       "--enable-languages=#{languages.join(",")}",
       # Make most executables versioned to avoid conflicts.
       "--program-suffix=-#{version_suffix}",


### PR DESCRIPTION
My system had trouble finding isl even with the --with-isl configure
options. Adding the brew LDFLAGS to boot-ldflags is probably more
desired in all cases because that will also set the rpath on our gcc
binaries to the linuxbrew lib path.

Note that by default `--with-boot-ldflags` has the `-static-libgcc` and `-static-libstdc++` set if empty so they need to be repeated.