### PR TITLE
chapel: fix link for linux

### DIFF
--- a/Library/Formula/chapel.rb
+++ b/Library/Formula/chapel.rb
@@ -27,8 +27,9 @@ class Chapel < Formula
     prefix.install_metafiles
 
     # Install chpl and other binaries (e.g. chpldoc) into bin/ as exec scripts.
-    bin.install Dir[libexec/"bin/darwin/*"]
-    bin.env_script_all_files libexec/"bin/darwin/", :CHPL_HOME => libexec
+    platform = "#{OS::NAME}#{Hardware::CPU.bits if OS.linux?}"
+    bin.install Dir[libexec/"bin/#{platform}/*"]
+    bin.env_script_all_files libexec/"bin/#{platform}/", :CHPL_HOME => libexec
     man1.install_symlink Dir["#{libexec}/man/man1/*.1"]
   end
 


### PR DESCRIPTION
Closes #876 

See https://gist.github.com/04fb73154746b7e279d5

Message:
> Warning: tried to install empty array to /home/bob/.linuxbrew/Cellar/chapel/1.12.0/bin