### PR TITLE
curl: fix for gssapi dependency on linux [Standalone linuxbrew] 

### DIFF
--- a/Library/Formula/curl.rb
+++ b/Library/Formula/curl.rb
@@ -37,6 +37,7 @@ class Curl < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "homebrew/dupes/krb5" => :build if build.with?("gssapi") unless OS.mac?
   depends_on "libidn" => :optional
   depends_on "rtmpdump" => :optional
   depends_on "libssh2" => :optional
@@ -81,7 +82,7 @@ class Curl < Formula
     args << (build.with?("libssh2") ? "--with-libssh2" : "--without-libssh2")
     args << (build.with?("libidn") ? "--with-libidn" : "--without-libidn")
     args << (build.with?("libmetalink") ? "--with-libmetalink" : "--without-libmetalink")
-    args << (build.with?("gssapi") ? "--with-gssapi" : "--without-gssapi")
+    args << (build.with?("gssapi") ? "--with-gssapi" + (OS.mac? ? "" : "=#{Formula["homebrew/dupes/krb5"].opt_prefix}") : "--without-gssapi")
     args << (build.with?("rtmpdump") ? "--with-librtmp" : "--without-librtmp")
 
     if build.with? "c-ares"


### PR DESCRIPTION
I think the provided fix is necessary for the Standalone installation.
Related [webpage](https://curl.haxx.se/mail/lib-2014-11/0187.html)

The command being executed: `brew install curl --with-gssapi`

Without the fix:
gist logs [here](https://gist.github.com/36a3011b62f48e16ff35)
```bash
$ ldd [Linuxbrew]/Cellar/curl/7.47.1/bin/curl
linux-vdso.so.1 (0x00007fffc8dff000)
libcurl.so.4 => [Linuxbrew]/lib/libcurl.so.4 (0x00007fa0f99db000)
libssl.so.1.0.0 => [Linuxbrew]/lib/libssl.so.1.0.0 (0x00007fa0f976a000)
libcrypto.so.1.0.0 => [Linuxbrew]/lib/libcrypto.so.1.0.0 (0x00007fa0f9317000)
libz.so.1 => [Linuxbrew]/lib/libz.so.1 (0x00007fa0f9105000)
libc.so.6 => [Linuxbrew]/lib/libc.so.6 (0x00007fa0f8d8c000)
libdl.so.2 => [Linuxbrew]/lib/libdl.so.2 (0x00007fa0f8b88000)
[Linuxbrew]/lib/ld.so (0x00007fa0f9c2f000)
```

With the fix:
gist logs [here](https://gist.github.com/8448af14bb610ca1d574)
```bash
$ ldd [Linuxbrew]/Cellar/curl/7.47.1/bin/curl
linux-vdso.so.1 (0x00007fff43579000)
libcurl.so.4 => [Linuxbrew]/lib/libcurl.so.4 (0x00007ffa258f8000)
libssl.so.1.0.0 => [Linuxbrew]/lib/libssl.so.1.0.0 (0x00007ffa25687000)
libcrypto.so.1.0.0 => [Linuxbrew]/lib/libcrypto.so.1.0.0 (0x00007ffa25234000)
libz.so.1 => [Linuxbrew]/lib/libz.so.1 (0x00007ffa25022000)
libc.so.6 => [Linuxbrew]/lib/libc.so.6 (0x00007ffa24ca9000)
libgssapi_krb5.so.2 => [Linuxbrew]/lib/libgssapi_krb5.so.2 (0x00007ffa24a6b000)
libkrb5.so.3 => [Linuxbrew]/lib/libkrb5.so.3 (0x00007ffa247b0000)
libk5crypto.so.3 => [Linuxbrew]/lib/libk5crypto.so.3 (0x00007ffa24585000)
libcom_err.so.3 => [Linuxbrew]/lib/libcom_err.so.3 (0x00007ffa24382000)
libdl.so.2 => [Linuxbrew]/lib/libdl.so.2 (0x00007ffa2417e000)
[Linuxbrew]/lib/ld.so (0x00007ffa25b50000)
libkrb5support.so.0 => [Linuxbrew]/lib/libkrb5support.so.0 (0x00007ffa23f74000)
libresolv.so.2 => [Linuxbrew]/lib/libresolv.so.2 (0x00007ffa23d5f000
```

**Update**:
Look at the end of config (search for "curl version:     7.47.1") and see `GSS-API support`

**Update 2**:
I was able to successfully build curl with GSSAPI support without the change introduced on line 85.
If someone desires to use system's gssapi, then change on line 85 has to go. But I lean towards keeping that change.

It would be nice to have `:standalone_linuxbrew` macro similar to `:build` and others...