### PR TITLE
kdiff3: fix for Linuxbrew

### DIFF
--- a/Library/Formula/kdiff3.rb
+++ b/Library/Formula/kdiff3.rb
@@ -9,8 +9,12 @@ class Kdiff3 < Formula
   def install
     # configure builds the binary
     system "./configure", "qt4"
-    prefix.install "releaseQt/kdiff3.app"
-    bin.install_symlink prefix+"kdiff3.app/Contents/MacOS/kdiff3"
+    if OS.mac?
+      prefix.install "releaseQt/kdiff3.app"
+      bin.install_symlink prefix+"kdiff3.app/Contents/MacOS/kdiff3"
+    else
+      bin.install "releaseQt/kdiff3"
+    end
   end
 
   test do


### PR DESCRIPTION
Message:
> Error: No such file or directory - releaseQt/kdiff3.app

