### PR TITLE
Update python.rb

### DIFF
--- a/Library/Formula/python.rb
+++ b/Library/Formula/python.rb
@@ -129,10 +129,14 @@ class Python < Formula
         cflags << "-I#{MacOS.sdk_path}/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers"
       end
     end
-    # Python's setup.py parses CPPFLAGS to learn search paths for the
-    # dependencies of the compiled extension modules.
-    # See Homebrew/linuxbrew#420 and Homebrew/linuxbrew#460
+    
+    # Python's setup.py parses CPPFLAGS and LDFLAGS to learn search paths for the
+    # dependencies of the compiled extension modules. Somehow it pulls these from
+    # the Makefile, NOT the environment, therefore these parameters must be passed
+    # to configure, not just set in the environment.
+    # See Homebrew/linuxbrew#420, Homebrew/linuxbrew#460, and Homebrew/linuxbrew#875
     cppflags << "-I#{HOMEBREW_PREFIX}/include" if OS.linux?
+    ldflags << "-L#{HOMEBREW_PREFIX}/lib" if OS.linux?
 
     # Avoid linking to libgcc https://code.activestate.com/lists/python-dev/112195/
     args << "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"


### PR DESCRIPTION
I added `-L#{HOMEBREW_PREFIX}/lib` to the LDFLAGS added to the argument list for configure. This is so that Python's setup.py can find "necessary bits" to build extensions. According to a note in Python setup.py's self.detect_modules(), LDFLAGS (along with CPPFLAGS) is somehow pulled from the Makefile, which means that these values must be passed as arguments to configure, not just set in the environment. This seems to explain why including these in std.rb did not work as expected.