### PR TITLE
gcc: remove 'lib.mkdir' for gcc-4.4

### DIFF
--- a/Library/Formula/gcc.rb
+++ b/Library/Formula/gcc.rb
@@ -111,7 +111,6 @@ class Gcc < Formula
     if build.with? "glibc"
       # Fix for GCC 4.4 and older that do not support -static-libstdc++
       # gengenrtl: error while loading shared libraries: libstdc++.so.6
-      lib.mkdir
       ln_s ["/usr/lib64/libstdc++.so.6", "/lib64/libgcc_s.so.1"], lib
       binutils = Formula["binutils"].prefix/"x86_64-unknown-linux-gnu/bin"
       args += [


### PR DESCRIPTION
Fix for `gcc` when built with glibc
```sh
Errno::EEXIST: File exists - [Linuxbrew]/Cellar/gcc/5.3.0/lib
```