### PR TITLE
libmetalink: add libxml2 build dependency on Linux

### DIFF
--- a/Library/Formula/libmetalink.rb
+++ b/Library/Formula/libmetalink.rb
@@ -12,6 +12,7 @@ class Libmetalink < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libxml2" => :build unless OS.mac?
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
`libmetalink` requires either `expat` or `libxml2` to successfully build on Linux. Here I add `libxml2` as a build dependency on Linux.