### PR TITLE
WORK IN PROGRESS libxcb 1.11.1 (new formula)

### DIFF
--- a/Library/Formula/libxau.rb
+++ b/Library/Formula/libxau.rb
@@ -1,0 +1,41 @@
+class Libxau < Formula
+  desc "Library for handling .XAuthority files"
+  homepage "http://www.x.org"
+  url "http://ftp.x.org/pub/individual/lib/libXau-1.0.8.tar.gz"
+  sha256 "c343b4ef66d66a6b3e0e27aa46b37ad5cab0f11a5c565eafb4a1c7590bc71d7b"
+  # tag "linuxbrew"
+
+  depends_on "pkg-config" => :build
+  depends_on "xproto"
+
+  resource "xorg-macros" do
+    url "http://xorg.freedesktop.org/releases/individual/util/util-macros-1.19.0.tar.bz2"
+    sha256 "2835b11829ee634e19fa56517b4cfc52ef39acea0cd82e15f68096e27cbed0ba"
+  end
+
+  def install
+    resource("xorg-macros").stage do
+      system "./configure", "--prefix=#{buildpath}/xorg-macros"
+      system "make", "install"
+    end
+
+    ENV.append_path "PKG_CONFIG_PATH", "#{buildpath}/xorg-macros/share/pkgconfig"
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <X11/Xauth.h>
+      #include <stdio.h>
+      int main(int argc, char** argv)
+      {
+          puts(XauFileName());
+          return 0;
+      }
+    EOS
+    flags = (ENV.cflags || "").split << "-I#{include}" << "-L#{lib}" << "-lXau"
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Library/Formula/libxcb.rb
+++ b/Library/Formula/libxcb.rb
@@ -1,0 +1,55 @@
+class Libxcb < Formula
+  desc "Modern base X11 library"
+  homepage "https://wiki.freedesktop.org/xcb/"
+  url "http://xcb.freedesktop.org/dist/libxcb-1.11.1.tar.gz"
+  sha256 "660312d5e64d0a5800262488042c1707a0261fa01a759bad265b1b75dd4844dd"
+  head "git://anongit.freedesktop.org/git/xcb/libxcb"
+  # tag "linuxbrew"
+
+  depends_on "xproto"
+  depends_on "libxau"
+  depends_on "libxslt"
+  depends_on "pkg-config" => :build
+  depends_on :python
+
+  resource "xcb-proto" do
+    url "http://xcb.freedesktop.org/dist/xcb-proto-1.11.tar.gz"
+    sha256 "d12152193bd71aabbdbb97b029717ae6d5d0477ab239614e3d6193cc0385d906"
+  end
+
+  resource "pthread-stubs" do
+    url "http://www.x.org/releases/X11R7.7/src/xcb/libpthread-stubs-0.3.tar.gz"
+    sha256 "3031f466cf0b06de6b3ccbf2019d15c4fcf75229b7d226a711bc1885b3a82cde"
+  end
+
+  def install
+    %w[pthread-stubs xcb-proto].each do |r|
+      resource(r).stage do
+        system "./configure", "--prefix=#{buildpath}/#{r}"
+        system "make", "install"
+      end
+    end
+
+    ENV.append_path "PKG_CONFIG_PATH", "#{buildpath}/xcb-proto/lib/pkgconfig"
+    ENV.append_path "PKG_CONFIG_PATH", "#{buildpath}/pthread-stubs/lib/pkgconfig"
+    system "./configure", "--disable-dependency-tracking",
+                          "--disable-silent-rules",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <xcb/xcb.h>
+      int main(int argc, char** argv)
+      {
+          xcb_connection_t* connection = xcb_connect(NULL, NULL);
+          xcb_disconnect(connection);
+          return 0;
+      }
+    EOS
+    flags = (ENV.cflags || "").split << "-I#{include}" << "-L#{lib}" << "-lxcb"
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Library/Formula/xproto.rb
+++ b/Library/Formula/xproto.rb
@@ -1,0 +1,26 @@
+class Xproto < Formula
+  desc "X11 Protocol library"
+  homepage "http://www.x.org"
+  url "http://www.x.org/releases/X11R7.7/src/proto/xproto-7.0.23.tar.gz"
+  sha256 "07efb40fdd23943ec554920eaf1fe175f70d20127c7a0ee8ab818bd88226f696"
+  # tag "linuxbrew"
+
+  def install
+    system "./configure", "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <X11/X.h>
+      int main(int argc, char** argv)
+      {
+          int xVersion = X_PROTOCOL;
+          return xVersion == 11 ? 0 : 1;
+      }
+    EOS
+    flags = (ENV.cflags || "").split << "-I#{include}"
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+  end
+end


### PR DESCRIPTION
This adds `libxcb`, a new formula for the client side of X11. It also includes the direct dependencies `libxau` and `xproto`.

TODO:
* [ ] Split resources out into separate formulae
* [X] Write tests
* [X] Verify all dependencies are 100% correct
* [X] Tag the formulae as exclusive to Linuxbrew
* [X] Update the versions - some of them are outdated