### PR TITLE
mono: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/mono.rb
+++ b/Library/Formula/mono.rb
@@ -60,6 +60,7 @@ class Mono < Formula
         ENV.prepend_path "PATH", bin
         ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
         system "./autogen.sh", "--prefix=#{prefix}"
+        system "mozroots", "--import", "--sync" unless OS.mac?
         system "make"
         system "make", "install"
       end


### PR DESCRIPTION
Closes #871 .
See https://gist.github.com/anonymous/118b82cbffcdde3474b3 .
Solution inspired by https://stackoverflow.com/questions/15181888/nuget-on-linux-error-getting-response-stream

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Note that the `mono` formula doesn't pass the audit, but it was already like that. When I get a few minutes I'll look and see if the upstream formula also has this problem and submit a PR to Homebrew as necessary.