### PR TITLE
tinyscheme: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/tinyscheme.rb
+++ b/Library/Formula/tinyscheme.rb
@@ -11,11 +11,11 @@ class Tinyscheme < Formula
   end
 
   # Modify compile flags for Mac OS X per instructions
-  patch :DATA
+  patch :DATA if OS.mac?
 
   def install
     system "make", "INITDEST=#{share}"
-    lib.install("libtinyscheme.dylib")
+    lib.install("libtinyscheme.#{OS.mac? ? "dylib" : "so"}")
     share.install("init.scm")
     bin.install("scheme")
   end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
+ [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Message:
> /home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3091: undefined reference to `exp'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3095: undefined reference to `log'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3099: undefined reference to `sin'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3103: undefined reference to `cos'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3107: undefined reference to `tan'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3111: undefined reference to `asin'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3115: undefined reference to `acos'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3120: undefined reference to `atan'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3123: undefined reference to `atan2'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3128: undefined reference to `sqrt'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3136: undefined reference to `pow'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3141: undefined reference to `floor'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3145: undefined reference to `ceil'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3152: undefined reference to `floor'
/home/bob/tmp/tinyscheme20160310-11643-156wirt/tinyscheme-1.40/scheme.c:3154: undefined reference to `ceil'

The gist-log is [here](https://gist.github.com/rwhogg/7e794f7f91b64649ed87) but it's not particularly illuminating.

Note that this formula does not have a test and therefore fails a strict audit.