### PR TITLE
nettle breaks if lib directory is already pr…

### DIFF
--- a/Library/Formula/nettle.rb
+++ b/Library/Formula/nettle.rb
@@ -28,7 +28,7 @@ class Nettle < Formula
     # Move lib64/* to lib/ on Linuxbrew
     lib64 = Pathname.new "#{lib}64"
     if lib64.directory?
-      lib.mkdir
+      lib.mkdir if !lib.directory?
       system "mv #{lib64}/* #{lib}/"
       rmdir lib64
       inreplace Dir[lib/"pkgconfig/*"], "/lib64", "/lib"


### PR DESCRIPTION
- [X ] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [X] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [X] Have you built your formula locally prior to submission with `brew install <formula>`?

only try to mkdir if directory is not already present. otherwise it errors out.