### PR TITLE
chromedriver: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/chromedriver.rb
+++ b/Library/Formula/chromedriver.rb
@@ -1,9 +1,18 @@
 class Chromedriver < Formula
   desc "Tool for automated testing of webapps across many browsers"
   homepage "https://sites.google.com/a/chromium.org/chromedriver/"
-  url "https://chromedriver.storage.googleapis.com/2.21/chromedriver_mac32.zip"
+  baseurl = "https://chromedriver.storage.googleapis.com/2.21/chromedriver_"
+  if OS.mac?
+    url "#{baseurl}mac32.zip"
+    sha256 "41f21005b498adc5896e4c3e264d718e4ade09609a7544ea8753d4e8ef1e787f"
+  elsif MacOS.prefer_64_bit?
+    url "#{baseurl}linux64.zip"
+    sha256 "8f0b879391e776e6741c8dc5016e7010c528c2007333c5220ad54dcc25de1cba"
+  else
+    url "#{baseurl}linux32.zip"
+    sha256 "1fbc3e4a7ff35d03d67be4a8a8dbd9b1b035fcc6a9b06fb18d466b710af89242"
+  end
   version "2.21"
-  sha256 "41f21005b498adc5896e4c3e264d718e4ade09609a7544ea8753d4e8ef1e787f"
 
   bottle :unneeded
 


### PR DESCRIPTION
The `chromedriver` build doesn't fail, it just downloads the wrong zip file.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
+ [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?
