### PR TITLE
packer: Fix for linuxbrew (set XC_OS from OS::NAME)

### DIFF
--- a/Library/Formula/packer.rb
+++ b/Library/Formula/packer.rb
@@ -354,7 +354,7 @@ class Packer < Formula
   end
 
   def install
-    ENV["XC_OS"] = "darwin"
+    ENV["XC_OS"] = OS::NAME
     ENV["XC_ARCH"] = MacOS.prefer_64_bit? ? "amd64" : "386"
     ENV["GOPATH"] = buildpath
     # For the gox buildtool used by packer, which doesn't need to


### PR DESCRIPTION
This sets XC_OS from OS::NAME instead of hardcoding "darwin".  This makes things work.

This only works if I've installed the python-dev package (via apt-get on an ubuntu 14.04 Digital Ocean droplet).  Without that there's a bit of a rabbit hole that I never figured out as packer needs mercurial which needs python's header files.