### PR TITLE
Describe preferred commit message format

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,9 @@ First time contributing to Homebrew? Read our [Code of Conduct](https://github.c
 * `brew edit foo` and make edits
 * leave the [`bottle`](http://www.rubydoc.info/github/Homebrew/homebrew/master/Formula#bottle-class_method) as-is
 * `brew install foo`, `brew test foo`, and `brew audit foo`
-* `git commit` with message formatted `foo: fix <insert details>`
+* `git commit` with summary formatted `foo: fix <insert details>`
+* if it is a portability fix, format it as `foo: Fix for Linuxbrew`
+* format the rest of the commit message according to [Chris Beams' guidelines](http://chris.beams.io/posts/git-commit/)
 * [open a pull request](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/How-To-Open-a-Homebrew-Pull-Request-(and-get-it-merged).md#how-to-open-a-homebrew-pull-request-and-get-it-merged) and fix any failing tests
 
 Thanks!


### PR DESCRIPTION
This PR updates `CONTRIBUTING.md`'s preferred commit message format for the case of simple portability fixes. This comes from the discussion [here](https://github.com/Linuxbrew/linuxbrew/pull/925#issuecomment-196098168).

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
