### PR TITLE
qwt: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/qwt.rb
+++ b/Library/Formula/qwt.rb
@@ -35,7 +35,7 @@ class Qwt < Formula
     # On Mavericks we want to target libc++, this requires a unsupported/macx-clang-libc++ flag
     if ENV.compiler == :clang && MacOS.version >= :mavericks
       args << "unsupported/macx-clang-libc++"
-    else
+    elsif OS.mac?
       args << "macx-g++"
     end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
+ [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

`qwt` was appending Mac-specific `qmake` flags.
Closes #927 
Strict audit fails because of a missing test.

Message:
> g++: error: 6.1: No such file or directory
g++: error: 6.1.2: No such file or directory
g++: error: libqwt.6.dylib: No such file or directory
g++: error: OpenGL: No such file or directory
g++: error: AGL: No such file or directory
g++: error: unrecognized command line option '-h'
g++: error: unrecognized command line option '-single_module'
...