### PR TITLE
chicken: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/chicken.rb
+++ b/Library/Formula/chicken.rb
@@ -17,12 +17,12 @@ class Chicken < Formula
     ENV.deparallelize
 
     args = %W[
-      PLATFORM=macosx
+      PLATFORM=#{OS.mac? ? "macosx" : OS::NAME}
       PREFIX=#{prefix}
       C_COMPILER=#{ENV.cc}
       LIBRARIAN=ar
-      POSTINSTALL_PROGRAM=install_name_tool
     ]
+    args << "POSTINSTALL_PROGRAM=install_name_tool" if OS.mac?
 
     # Sometimes chicken detects a 32-bit environment by mistake, causing errors,
     # see https://github.com/Homebrew/homebrew/issues/45648


### PR DESCRIPTION
Counting both issues and PR's, I think this is the 4th LISP formula I've worked on for Linuxbrew...

See https://gist.github.com/rwhogg/a1081273c044f5b10d68#file-01-make-L201
```
/home/bob/.linuxbrew/bin/gcc-5 -fno-strict-aliasing -fwrapv -fno-common -DHAVE_CHICKEN_CONFIG_H -m64 -DC_ENABLE_PTABLES -c -Os -fomit-frame-pointer  -DC_BUILDING_LIBCHICKEN lolevel.c -o lolevel-static.o -I. -I./
rules.make:131: recipe for target 'lolevel-static.o' failed
make: *** [lolevel-static.o] Interrupt
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
+ [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?