### PR TITLE
infer: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/infer.rb
+++ b/Library/Formula/infer.rb
@@ -1,8 +1,13 @@
 class Infer < Formula
   desc "Static analyzer for Java, C and Objective-C"
   homepage "http://fbinfer.com/"
-  url "https://github.com/facebook/infer/releases/download/v0.8.0/infer-osx-v0.8.0.tar.xz"
-  sha256 "2b494a2b595bd7cf0f0cfaac4e9bece568575a4bcf25cc00161ed34c0319dc58"
+  if OS.mac?
+    url "https://github.com/facebook/infer/releases/download/v0.8.0/infer-osx-v0.8.0.tar.xz"
+    sha256 "2b494a2b595bd7cf0f0cfaac4e9bece568575a4bcf25cc00161ed34c0319dc58"
+  elsif OS.linux?
+    url "https://github.com/facebook/infer/releases/download/v0.8.0/infer-linux64-v0.8.0.tar.xz"
+    sha256 "4942ca2c8ad9e76ff6e31c6473b7f360cc95d9db43218dc7747ae34aef6294f4"
+  end
 
   bottle do
     cellar :any


### PR DESCRIPTION
`infer` was downloading a Mac-only tarball.

See https://gist.github.com/rwhogg/6ef9da049a936f34c976#file-07-build-infer-sh-L14
```
checking whether the C compiler works... no
configure: error: in `/home/bob/tmp/infer20160318-15631-j2yvf8/infer-osx-v0.7.0':
configure: error: C compiler cannot create executables
See `config.log' for more details
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
+ [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?