### PR TITLE
vala: Depends on flex for Linuxbrew

### DIFF
--- a/Library/Formula/vala.rb
+++ b/Library/Formula/vala.rb
@@ -16,6 +16,7 @@ class Vala < Formula
   end
 
   depends_on "pkg-config" => :run
+  depends_on "flex" => :build unless OS.mac?
   depends_on "gettext"
   depends_on "glib"
 


### PR DESCRIPTION
```
$ brew install vala
==> Downloading https://download.gnome.org/sources/vala/0.30/vala-0.30.1.tar.xz
==> Downloading from http://ftp.heanet.ie/mirrors/ftp.gnome.org/sources/vala/0.30/vala-0.30.1.tar.xz
######################################################################## 100.0%
==> ./configure --disable-silent-rules --prefix=/home/linuxbrew/.linuxbrew/Cellar/vala/0.30.1
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/vala/01.configure:
checking if /home/linuxbrew/.linuxbrew/bin/gcc-5 static flag -static works... yes
checking if /home/linuxbrew/.linuxbrew/bin/gcc-5 supports -c -o file.o... yes
checking if /home/linuxbrew/.linuxbrew/bin/gcc-5 supports -c -o file.o... (cached) yes
checking whether the /home/linuxbrew/.linuxbrew/bin/gcc-5 linker (/home/linuxbrew/.linuxbrew/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... no
checking whether ln -s works... yes
checking for flex... no
checking for lex... no
configure: error: flex not found but required
```