### PR TITLE
bison: Depends on m4 for Linuxbrew

### DIFF
--- a/Library/Formula/bison.rb
+++ b/Library/Formula/bison.rb
@@ -14,6 +14,8 @@ class Bison < Formula
 
   keg_only :provided_by_osx, "Some formulae require a newer version of bison."
 
+  depends_on "homebrew/dupes/m4" => :build unless OS.mac?
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
```
==> Downloading http://ftpmirror.gnu.org/bison/bison-3.0.4.tar.gz
==> Downloading from http://ftp.task.gda.pl/pub/gnu/bison/bison-3.0.4.tar.gz
######################################################################## 100.0%
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/bison/3.0.4
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/bison/01.configure:
checking for special C compiler options needed for large files... no
checking for _FILE_OFFSET_BITS value needed for large files... no
checking whether pragma GCC diagnostic push works... yes
checking whether /home/linuxbrew/.linuxbrew/bin/gcc-5 supports POSIXLY_CORRECT=1... yes
checking whether /home/linuxbrew/.linuxbrew/bin/g++-5 builds executables that work... yes
checking whether /home/linuxbrew/.linuxbrew/bin/g++-5 supports POSIXLY_CORRECT=1... yes
checking for flex... no
checking for lex... no
checking for bison... no
checking for byacc... no
checking for ranlib... (cached) ranlib
checking for GNU M4 that supports accurate traces... configure: error: no acceptable m4 could be found in $PATH.
GNU M4 1.4.6 or later is required; 1.4.16 or newer is recommended.
GNU M4 1.4.15 uses a buggy replacement strstr on some systems.
Glibc 2.9 - 2.12 and GNU M4 1.4.11 - 1.4.15 have another strstr bug.
```