### PR TITLE
flex: Depends on bison for Linuxbrew

### DIFF
--- a/Library/Formula/flex.rb
+++ b/Library/Formula/flex.rb
@@ -13,6 +13,7 @@ class Flex < Formula
   keg_only :provided_by_osx, "Some formulae require a newer version of flex."
 
   depends_on "gettext"
+  depends_on "bison" => :build unless OS.mac?
 
   def install
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
```
==> Downloading https://downloads.sourceforge.net/flex/flex-2.6.0.tar.bz2
==> Downloading from http://netcologne.dl.sourceforge.net/project/flex/flex-2.6.0.tar.bz2
######################################################################## 100.0%
==> ./configure --disable-shared --prefix=/home/linuxbrew/.linuxbrew/Cellar/flex/2.6.0
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/flex/01.configure:
checking whether the /home/linuxbrew/.linuxbrew/bin/g++-5 linker (/home/linuxbrew/.linuxbrew/bin/ld -m elf_x86_64) supports shared libraries... yes
checking for /home/linuxbrew/.linuxbrew/bin/g++-5 option to produce PIC... -fPIC -DPIC
checking if /home/linuxbrew/.linuxbrew/bin/g++-5 PIC flag -fPIC -DPIC works... yes
checking if /home/linuxbrew/.linuxbrew/bin/g++-5 static flag -static works... yes
checking if /home/linuxbrew/.linuxbrew/bin/g++-5 supports -c -o file.o... yes
checking if /home/linuxbrew/.linuxbrew/bin/g++-5 supports -c -o file.o... (cached) yes
checking whether the /home/linuxbrew/.linuxbrew/bin/g++-5 linker (/home/linuxbrew/.linuxbrew/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking dependency style of /home/linuxbrew/.linuxbrew/bin/g++-5... none
checking whether ln -s works... yes
checking for gawk... (cached) mawk
checking for bison... bison
checking for help2man... help2man
checking for m4 that supports -P... configure: error: could not find m4 that supports -P
```