### PR TITLE
nettle: Depends on m4 for Linuxbrew

### DIFF
--- a/Library/Formula/nettle.rb
+++ b/Library/Formula/nettle.rb
@@ -13,6 +13,7 @@ class Nettle < Formula
   end
 
   depends_on "gmp"
+  depends_on "homebrew/dupes/m4" => :build unless OS.mac?
 
   def install
     # OS X doesn't use .so libs. Emailed upstream 04/02/2016.


### PR DESCRIPTION
```
==> Downloading https://www.lysator.liu.se/~nisse/archive/nettle-3.2.tar.gz
Already downloaded: /home/linuxbrew/.cache/Homebrew/nettle-3.2.tar.gz
==> ./configure --prefix=/home/linuxbrew/.linuxbrew/Cellar/nettle/3.2 --enable-shared
==> make
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/nettle/02.make:
        -o gcmdata
/home/linuxbrew/.linuxbrew/bin/gcc-5 -I. -isystem/home/linuxbrew/.linuxbrew/include -DHAVE_CONFIG_H -Os -w -pipe -march=core2 -ggdb3 -Wall -W   -Wmissing-prototypes -Wmissing-dec
larations -Wstrict-prototypes   -Wpointer-arith -Wbad-function-cast -Wnested-externs -fpic  -c getopt.c \
        && true
/home/linuxbrew/.linuxbrew/bin/gcc-5 -I. -isystem/home/linuxbrew/.linuxbrew/include -DHAVE_CONFIG_H -Os -w -pipe -march=core2 -ggdb3 -Wall -W   -Wmissing-prototypes -Wmissing-dec
larations -Wstrict-prototypes   -Wpointer-arith -Wbad-function-cast -Wnested-externs -fpic  -c getopt1.c \
        && true
/home/linuxbrew/.linuxbrew/bin/gcc-5 -I. -isystem/home/linuxbrew/.linuxbrew/include -DHAVE_CONFIG_H -Os -w -pipe -march=core2 -ggdb3 -Wall -W   -Wmissing-prototypes -Wmissing-dec
larations -Wstrict-prototypes   -Wpointer-arith -Wbad-function-cast -Wnested-externs -fpic  -c nettle-internal.c \
        && true
m4 ./asm.m4 machine.m4 config.m4 aes-decrypt-internal.asm >aes-decrypt-internal.s
/home/linuxbrew/.linuxbrew/bin/gcc-5 -I. -isystem/home/linuxbrew/.linuxbrew/include -DHAVE_CONFIG_H -Os -w -pipe -march=core2 -ggdb3 -Wall -W   -Wmissing-prototypes -Wmissing-dec
larations -Wstrict-prototypes   -Wpointer-arith -Wbad-function-cast -Wnested-externs -fpic  -c aes-decrypt.c \
        && true
/bin/sh: 1: m4: not found
make[1]: *** [aes-decrypt-internal.o] Error 127
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory `/tmp/nettle20160320-11846-j1l6rj/nettle-3.2'
make: *** [all] Error 2
```