### PR TITLE
fontconfig: Depends on expat for Linuxbrew

### DIFF
--- a/Library/Formula/fontconfig.rb
+++ b/Library/Formula/fontconfig.rb
@@ -26,6 +26,7 @@ class Fontconfig < Formula
   option :universal
 
   depends_on "pkg-config" => :build
+  depends_on "expat" unless OS.mac?
   depends_on "freetype"
 
   # Reverts commit http://cgit.freedesktop.org/fontconfig/commit/?id=7a6622f25cdfab5ab775324bef1833b67109801b,


### PR DESCRIPTION
```
==> Installing fontconfig
==> Downloading https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.11.1.tar.bz2
######################################################################## 100.0%
==> Patching
patching file fc-cache/fc-cache.c
patching file fontconfig/fontconfig.h
patching file src/fccache.c
patching file src/fcdir.c
patching file src/fcfs.c
patching file src/fcint.h
patching file src/fcpat.c
==> ./configure --disable-silent-rules --enable-static --with-add-fonts=/System/Library/Fonts,/Library/Fonts,~/Library/Fonts --prefix=/home/linuxbrew/.linuxbrew/Cellar/fontconfig
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/fontconfig/01.configure:
checking for FT_Get_BDF_Property... yes
checking for FT_Get_PS_Font_Info... yes
checking for FT_Has_PS_Glyph_Names... yes
checking for FT_Get_X11_Font_Format... yes
checking for FT_Select_Size... yes
checking for FT_Bitmap_Size.y_ppem... yes
checking for EXPAT... no
checking expat.h usability... no
checking expat.h presence... no
checking for expat.h... no
checking xmlparse.h usability... no
checking xmlparse.h presence... no
checking for xmlparse.h... no
configure: error: 
*** expat is required. or try to use --enable-libxml2
```