### PR TITLE
libfuse: Depends on autoconf, automake, libtool for Linuxbrew

### DIFF
--- a/Library/Formula/libfuse.rb
+++ b/Library/Formula/libfuse.rb
@@ -7,6 +7,9 @@ class Libfuse < Formula
   # tag "linuxbrew"
 
   depends_on "gettext"
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
 
   def install
     cp Formula["gettext"].pkgshare/"config.rpath", "."


### PR DESCRIPTION
```
==> Installing libfuse
==> Downloading https://github.com/libfuse/libfuse/archive/fuse_2_9_5.tar.gz
==> Downloading from https://codeload.github.com/libfuse/libfuse/tar.gz/fuse_2_9_5
######################################################################## 100.0%
==> ./makeconf.sh
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/libfuse/01.makeconf.sh:
2016-03-20 15:08:19 +0000

./makeconf.sh

Running libtoolize...
./makeconf.sh: 4: ./makeconf.sh: libtoolize: not found
Running autoreconf...
./makeconf.sh: 25: ./makeconf.sh: autoreconf: not found
```