### PR TITLE
systemd: depends on m4, pkg-config

### DIFF
--- a/Library/Formula/systemd.rb
+++ b/Library/Formula/systemd.rb
@@ -6,9 +6,11 @@ class Systemd < Formula
   # tag "linuxbrew"
 
   depends_on "homebrew/dupes/gperf" => :build
+  depends_on "homebrew/dupes/m4" => :build
   depends_on "gettext" => :build
   depends_on "intltool" => :build
   depends_on "libcap"
+  depends_on "pkg-config" => :build
   depends_on "util-linux" # for libmount
   depends_on "XML::Parser" => :perl
 


### PR DESCRIPTION
Lack of `pkg-config` shows its head in a cryptic manner:

```
==> Installing systemd
==> Downloading http://www.freedesktop.org/software/systemd/systemd-221.tar.xz
==> Downloading from https://www.freedesktop.org/software/systemd/systemd-221.tar.xz
######################################################################## 100.0%
==> ./configure --disable-silent-rules --prefix=/home/linuxbrew/.linuxbrew/Cellar/systemd/221 --with-rootprefix=/home/linuxbrew/.linuxbrew/Cellar/systemd/221 --with-sysvinit-path
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/systemd/01.configure:
checking whether IFLA_VTI_REMOTE is declared... yes
checking whether IFLA_PHYS_PORT_ID is declared... yes
checking whether IFLA_BOND_AD_INFO is declared... yes
checking whether IFLA_VLAN_PROTOCOL is declared... yes
checking whether IFLA_VXLAN_REMCSUM_NOPARTIAL is declared... no
checking whether IFLA_IPTUN_6RD_RELAY_PREFIXLEN is declared... yes
checking whether IFLA_BRIDGE_VLAN_INFO is declared... yes
checking whether IFLA_BRPORT_UNICAST_FLOOD is declared... yes
checking whether NDA_IFINDEX is declared... yes
checking whether IFA_FLAGS is declared... yes
checking for DBUS... no
checking for XKBCOMMON... no
checking for BLKID... no
checking for MOUNT... no
configure: error: *** libmount support required but libraries not found
```

The we have problem with missing `m4`:

```
==> Downloading http://www.freedesktop.org/software/systemd/systemd-221.tar.xz
Already downloaded: /home/linuxbrew/.cache/Homebrew/systemd-221.tar.xz
==> ./configure --disable-silent-rules --prefix=/home/linuxbrew/.linuxbrew/Cellar/systemd/221 --with-rootprefix=/home/linuxbrew/.linuxbrew/Cellar/systemd/221 --with-sysvinit-path
==> make install
Last 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/systemd/02.make:
mawk 'BEGIN { print "/* GENERATED FILE */\n#define ORDERED" } \
                           { if (!match($0, "^#include"))          \
                                 gsub(/hashmap/, "ordered_hashmap"); \
                             gsub(/HASHMAP/, "ORDERED_HASHMAP");     \
                             gsub(/Hashmap/, "OrderedHashmap");      \
                             print }' <src/test/test-hashmap-plain.c >src/test/test-hashmap-ordered.c
mawk 'BEGIN{ print "const char *dns_type_to_string(int type) {\n\tswitch(type) {" } {printf "        case DNS_TYPE_%s: return ", $1; sub(/_/, "-"); printf "\"%s\";\n", $1 } END{ 
print "        default: return NULL;\n\t}\n}\n" }' <src/resolve/dns_type-list.txt >src/resolve/dns_type-to-name.h
/bin/mkdir -p src/core/
/bin/mkdir -p src/core/
gperf < src/core/load-fragment-gperf.gperf > src/core/load-fragment-gperf.c
mawk 'BEGIN{ keywords=0 ; FS="," ; print "extern const char load_fragment_gperf_nulstr[];" ; print "const char load_fragment_gperf_nulstr[] ="} ; keyword==1 { print "\"" $1 "\\0\
"" } ; /%%/ { keyword=1} ; END { print ";" }' < src/core/load-fragment-gperf.gperf > src/core/load-fragment-gperf-nulstr.c
(standard input): The input file is empty!
make: *** [src/core/load-fragment-gperf.c] Error 1
make: *** Deleting file `src/core/load-fragment-gperf.c'
make: *** Waiting for unfinished jobs....
```

And after that the `CFLAGS` deal:

```
==> ./configure --disable-silent-rules --prefix=/home/linuxbrew/.linuxbrew/Cellar/systemd/221 --with-rootprefix=/home/linuxbrew/.linuxbrew/Cellar/systemd/221 --with-sysvinit-path
==> make install
^[ORLast 15 lines from /home/linuxbrew/.cache/Homebrew/Logs/systemd/02.make:
libtool: link: ( cd ".libs" && rm -f "libsystemd.la" && ln -s "../libsystemd.la" "libsystemd.la" )
/usr/bin/ld.gold: error: /tmp/ccBczM3e.ltrans2.ltrans.o: requires dynamic R_X86_64_PC32 reloc against 'program_invocation_short_name' which may overflow at runtime; recompile wit
h -fPIC
/usr/bin/ld.gold: error: /tmp/ccBczM3e.ltrans24.ltrans.o: requires dynamic R_X86_64_PC32 reloc against 'program_invocation_short_name' which may overflow at runtime; recompile wi
th -fPIC
/usr/bin/ld.gold: error: /tmp/ccBczM3e.ltrans24.ltrans.o: requires dynamic R_X86_64_PC32 reloc against 'program_invocation_short_name' which may overflow at runtime; recompile wi
th -fPIC
collect2: error: ld returned 1 exit status
make[2]: *** [systemd-cgls] Error 1
/usr/bin/ld.gold: error: /tmp/ccFiTAx9.ltrans0.ltrans.o: requires dynamic R_X86_64_PC32 reloc against 'optind' which may overflow at runtime; recompile with -fPIC
/usr/bin/ld.gold: error: /tmp/ccFiTAx9.ltrans3.ltrans.o: requires dynamic R_X86_64_PC32 reloc against 'optarg' which may overflow at runtime; recompile with -fPIC
/usr/bin/ld.gold: error: /tmp/ccFiTAx9.ltrans21.ltrans.o: requires dynamic R_X86_64_PC32 reloc against 'environ' which may overflow at runtime; recompile with -fPIC
/usr/bin/ld.gold: error: /tmp/ccFiTAx9.ltrans25.ltrans.o: requires dynamic R_X86_64_PC32 reloc against 'program_invocation_short_name' which may overflow at runtime; recompile wi
th -fPIC
/usr/bin/ld.gold: error: /tmp/ccFiTAx9.ltrans25.ltrans.o: requires dynamic R_X86_64_PC32 reloc against 'program_invocation_short_name' which may overflow at runtime; recompile wi
th -fPIC
collect2: error: ld returned 1 exit status
make[2]: *** [systemd-nspawn] Error 1
make[1]: *** [install-recursive] Error 1
make: *** [install] Error 2
```