### PR TITLE
sbcl: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/sbcl.rb
+++ b/Library/Formula/sbcl.rb
@@ -25,19 +25,29 @@ class Sbcl < Formula
 
   # Current binary versions are listed at http://sbcl.sourceforge.net/platform-table.html
   resource "bootstrap64" do
-    url "https://downloads.sourceforge.net/project/sbcl/sbcl/1.1.8/sbcl-1.1.8-x86-64-darwin-binary.tar.bz2"
-    sha256 "729054dc27d6b53bd734eac4dffeaa9e231e97bdbe4927d7a68c8f0210cad700"
+    if OS.mac?
+      url "https://downloads.sourceforge.net/project/sbcl/sbcl/1.1.8/sbcl-1.1.8-x86-64-darwin-binary.tar.bz2"
+      sha256 "729054dc27d6b53bd734eac4dffeaa9e231e97bdbe4927d7a68c8f0210cad700"
+    elsif OS.linux?
+      url "https://downloads.sourceforge.net/project/sbcl/sbcl/1.3.3/sbcl-1.3.3-x86-64-linux-binary.tar.bz2"
+      sha256 "e8b1730c42e4a702f9b4437d9842e91cb680b7246f88118c7443d7753e61da65"
+    end
   end
 
   resource "bootstrap32" do
-    url "https://downloads.sourceforge.net/project/sbcl/sbcl/1.1.6/sbcl-1.1.6-x86-darwin-binary.tar.bz2"
-    sha256 "5801c60e2a875d263fccde446308b613c0253a84a61ab63569be62eb086718b3"
+    if OS.mac?
+      url "https://downloads.sourceforge.net/project/sbcl/sbcl/1.1.6/sbcl-1.1.6-x86-darwin-binary.tar.bz2"
+      sha256 "5801c60e2a875d263fccde446308b613c0253a84a61ab63569be62eb086718b3"
+    elsif OS.linux?
+      url "https://downloads.sourceforge.net/project/sbcl/sbcl/1.2.7/sbcl-1.2.7-x86-linux-binary.tar.bz2"
+      sha256 "724425fe0d28747c7d31c6655e39fa8c27f9ef4608c482ecc60089bcc85fc31d"
+    end
   end
 
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/patches/c5ffdb11/sbcl/patch-base-target-features.diff"
     sha256 "e101d7dc015ea71c15a58a5c54777283c89070bf7801a13cd3b3a1969a6d8b75"
-  end
+  end if OS.mac?
 
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/patches/c5ffdb11/sbcl/patch-make-doc.diff"


### PR DESCRIPTION
Closes Linuxbrew/linuxbrew#949 .

There were two problems:
1. We were bootstrapping using Mac binaries
2. One of the patches doesn't work on Linux.

See https://gist.github.com/rwhogg/c750958273a5e0048a09#file-01-make-sh-L48
```
��Y��: not found
/home/bob/tmp/sbcl--bootstrap6420160312-9981-1fk801v/sbcl-1.1.8-x86-64-darwin/src/runtime/sbcl: 1: /home/bob/tmp/sbcl--bootstrap6420160312-9981-1fk801v/sbcl-1.1.8-x86-64-darwin/src/runtime/sbcl: ����������x���H__PAGEZERO��x�__TEXT�: not found
/home/bob/tmp/sbcl--bootstrap6420160312-9981-1fk801v/sbcl-1.1.8-x86-64-darwin/src/runtime/sbcl: 2: /home/bob/tmp/sbcl--bootstrap6420160312-9981-1fk801v/sbcl-1.1.8-x86-64-darwin/src/runtime/sbcl: �: not found
/home/bob/tmp/sbcl--bootstrap6420160312-9981-1fk801v/sbcl-1.1.8-x86-64-darwin/src/runtime/sbcl: 3: /home/bob/tmp/sbcl--bootstrap6420160312-9981-1fk801v/sbcl-1.1.8-x86-64-darwin/src/runtime/sbcl: Syntax error: "(" unexpected
Command exited with non-zero status 1
0.00user 0.00system 0:00.25elapsed 3%CPU (0avgtext+0avgdata 1656maxresident)k
0inputs+8outputs (0major+246minor)pagefaults 0swaps
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
+ [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?