### PR TITLE
cvs: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/cvs.rb
+++ b/Library/Formula/cvs.rb
@@ -3,6 +3,12 @@
 # MacPorts: https://trac.macports.org/browser/trunk/dports/devel/cvs/Portfile
 # Creating a useful testcase: http://mrsrl.stanford.edu/~brian/cvstutorial/
 
+class VimRequirement < Requirement
+  fatal true
+  default_formula "vim"
+  satisfy { which "vim" }
+end
+
 class Cvs < Formula
   desc "Version control system"
   homepage "http://cvs.nongnu.org/"
@@ -20,21 +26,23 @@ class Cvs < Formula
 
   keg_only :provided_until_xcode5
 
+  depends_on VimRequirement
+
   patch :p0 do
     url "https://opensource.apple.com/tarballs/cvs/cvs-45.tar.gz"
     sha256 "4d200dcf0c9d5044d85d850948c88a07de83aeded5e14fa1df332737d72dc9ce"
-    apply "patches/PR5178707.diff",
+    apply *["patches/PR5178707.diff",
           "patches/ea.diff",
           "patches/endian.diff",
           "patches/fixtest-client-20.diff",
           "patches/fixtest-recase.diff",
           "patches/i18n.diff",
           "patches/initgroups.diff",
-          "patches/nopic.diff",
+          ("patches/nopic.diff" if OS.mac?),
           "patches/remove-libcrypto.diff",
           "patches/remove-info.diff",
           "patches/tag.diff",
-          "patches/zlib.diff"
+          "patches/zlib.diff"].compact
   end
 
   def install


### PR DESCRIPTION
There were two problems with `cvs`:

1\. It depends on `vim`, which isn't necessarily installed by default on Linux (Slackware uses `elvis` instead, but I noticed because I actually manually removed it from my Ubuntu system!)

```
checking for vim... no
configure: error:
   Failed to find a text file editor.  CVS cannot be compiled
   without a default log message editor.  Searched for
   vim'.  Try configure --with-editor'.
```

2\. There was a patch which added an unsupported `gcc` flag.

```
make[2]: *** Waiting for unfinished jobs....
Makefile:572: recipe for target 'admin.o' failed
make[2]: *** [admin.o] Error 1
gcc-5: error: unrecognized command line option '-mdynamic-no-pic'
gcc-5: error: unrecognized command line option '-mdynamic-no-pic'
Makefile:572: recipe for target 'annotate.o' failed
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?