### PR TITLE
attr: install headers

### DIFF
--- a/Library/Formula/attr.rb
+++ b/Library/Formula/attr.rb
@@ -14,7 +14,7 @@ class Attr < Formula
       "--disable-dependency-tracking",
       "--disable-silent-rules",
       "--prefix=#{prefix}"
-    system "make", "install", "install-lib"
+    system "make", "install", "install-lib", "install-dev"
   end
 
   test do


### PR DESCRIPTION
Other formulae that depend on attr cannot be properly compiled if headers are not installed.