### PR TITLE
gtk+: depends on cairo --with-x11 for Linuxbrew

### DIFF
--- a/Library/Formula/gtk+.rb
+++ b/Library/Formula/gtk+.rb
@@ -29,6 +29,7 @@ class Gtkx < Formula
   depends_on "gdk-pixbuf"
   depends_on "jasper" => :optional
   depends_on "atk"
+  depends_on "cairo" => "with-x11" unless OS.mac?
   depends_on "pango"
   depends_on "gobject-introspection"
   depends_on "hicolor-icon-theme"


### PR DESCRIPTION
As reported in #632