### PR TITLE
opam: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/opam.rb
+++ b/Library/Formula/opam.rb
@@ -16,6 +16,7 @@ class Opam < Formula
 
   depends_on "ocaml" => :recommended
   depends_on "camlp4" => :recommended if build.with? "ocaml"
+  depends_on "homebrew/dupes/unzip" unless OS.mac?
 
   # aspcud has a fairly large buildtime dep tree, and uses gringo,
   # which requires C++11 and is inconvenient to install pre-10.8


### PR DESCRIPTION
`opam` needs `unzip` to operate correctly.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?