### PR TITLE
zsh: Depends on ncurses for Linuxbrew

### DIFF
--- a/Library/Formula/zsh.rb
+++ b/Library/Formula/zsh.rb
@@ -23,6 +23,7 @@ class Zsh < Formula
   depends_on "gdbm"
   depends_on "pcre"
   depends_on "texinfo" unless OS.mac?
+  depends_on "homebrew/dupes/ncurses" unless OS.mac?
 
   def install
     system "Util/preconfig" if build.head?


### PR DESCRIPTION
`zsh` depends on `ncurses`.

```
configure: error: in `/home/bob/tmp/zsh20160324-12221-1iabe4a/zsh-5.2':
configure: error: "No terminal handling library was found on your system.
This is probably a library called 'curses' or 'ncurses'.  You may
need to install a package called 'curses-devel' or 'ncurses-devel' on your
system."
See `config.log' for more details
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

There are unresolved issues building `ncurses` on my machine at the moment; I'm going to leave this PR open until those are resolved.

Similarly, `zsh` doesn't pass a strict audit, but that should be fixed upstream.