### PR TITLE
pcre: Depends on zlib for Linuxbrew

### DIFF
--- a/Library/Formula/pcre.rb
+++ b/Library/Formula/pcre.rb
@@ -29,6 +29,7 @@ class Pcre < Formula
   end
 
   depends_on "bzip2" unless OS.mac?
+  depends_on "zlib" unless OS.mac?
 
   def install
     ENV.universal_binary if build.universal?


### PR DESCRIPTION
See https://github.com/Linuxbrew/linuxbrew/pull/984#issuecomment-201155848

```
** Cannot --enable-pcregrep-libz because zlib.h was not found
==> Formula
Path: /home/linuxbrew/.linuxbrew/Library/Formula/pcre.rb
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Again, fails a strict audit, but needs to be fixed upstream.