### PR TITLE
jsvc: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/jsvc.rb
+++ b/Library/Formula/jsvc.rb
@@ -11,15 +11,17 @@ class Jsvc < Formula
   depends_on :java
 
   def install
-    ENV.append "CFLAGS", "-arch #{MacOS.preferred_arch}"
-    ENV.append "LDFLAGS", "-arch #{MacOS.preferred_arch}"
-    ENV.append "CPPFLAGS", "-I/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers"
+    if OS.mac?
+      ENV.append "CFLAGS", "-arch #{MacOS.preferred_arch}"
+      ENV.append "LDFLAGS", "-arch #{MacOS.preferred_arch}"
+      ENV.append "CPPFLAGS", "-I/System/Library/Frameworks/JavaVM.framework/Versions/Current/Headers"
+    end
 
     prefix.install %w[NOTICE.txt LICENSE.txt RELEASE-NOTES.txt]
 
     cd "unix"
-    system "./configure", "--with-java=/System/Library/Frameworks/JavaVM.framework",
-                          "--with-os-type=Headers"
+    system "./configure", ("--with-java=/System/Library/Frameworks/JavaVM.framework" if OS.mac?),
+                          ("--with-os-type=Headers" if OS.mac?)
     system "make"
     bin.install "jsvc"
   end


### PR DESCRIPTION
`jsvc` was using Mac-specific paths and configure flags.

See [https://gist.github.com/rwhogg/544f7f2c0659ad40d5c2#file-01-configure-L27]
> configure: error: /System/Library/Frameworks/JavaVM.framework is not a directory

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Strict audit fails because of missing test.