### PR TITLE
blahtexml: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/blahtexml.rb
+++ b/Library/Formula/blahtexml.rb
@@ -21,10 +21,11 @@ class Blahtexml < Formula
   end
 
   def install
-    system "make", "blahtex-mac"
+    os = OS.mac? ? "mac" : OS::NAME
+    system "make", "blahtex-#{os}"
     bin.install "blahtex"
     if build.with? "blahtexml"
-      system "make", "blahtexml-mac"
+      system "make", "blahtexml-#{os}"
       bin.install "blahtexml"
     end
   end


### PR DESCRIPTION
`blahtexml` has separate Makefile targets for Linux and OS X.

See https://gist.github.com/rwhogg/856c64b5fbabf4aaf219#file-01-make-L26:
> collect2: error: ld returned 1 exit status
make: *** [blahtex-mac] Error 1

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [ ] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

As usual, fails a strict audit because of a missing test.