### PR TITLE
d-bus: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/d-bus.rb
+++ b/Library/Formula/d-bus.rb
@@ -21,6 +21,8 @@ class DBus < Formula
     sha256 "a8aa6fe3f2d8f873ad3f683013491f5362d551bf5d4c3b469f1efbc5459a20dc"
   end
 
+  depends_on "expat" unless OS.mac?
+
   def install
     # Fix the TMPDIR to one D-Bus doesn't reject due to odd symbols
     ENV["TMPDIR"] = "/tmp"
@@ -31,8 +33,8 @@ class DBus < Formula
                           "--sysconfdir=#{etc}",
                           "--disable-xml-docs",
                           "--disable-doxygen-docs",
-                          "--enable-launchd",
-                          "--with-launchd-agent-dir=#{prefix}",
+                          ("--enable-launchd" if OS.mac?),
+                          ("--with-launchd-agent-dir=#{prefix}" if OS.mac?),
                           "--without-x",
                           "--disable-tests"
     system "make"


### PR DESCRIPTION
`d-bus` was using `launchd`, but that's only available on OS X.

Closes Linuxbrew/linuxbrew#987 .

From the issue:
> configure: error: launchd support explicitly enabled but not available

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?