### PR TITLE
xerces-c: Depends on icu4c and curl for Linuxbrew

### DIFF
--- a/Library/Formula/xerces-c.rb
+++ b/Library/Formula/xerces-c.rb
@@ -13,6 +13,9 @@ class XercesC < Formula
 
   option :universal
 
+  depends_on "icu4c" unless OS.mac?
+  depends_on "curl" unless OS.mac?
+
   def install
     ENV.universal_binary if build.universal?
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
According to Xerces' web page, 5 different transcoders are supported:

```
--enable-transcoder-gnuiconv    use the GNU iconv library 
--enable-transcoder-iconv   use the iconv library 
--enable-transcoder-icu     use the ICU library 
--enable-transcoder-macosunicodeconverter   use Mac OS X APIs (only on Mac OS X) 
--enable-transcoder-windows     use Windows APIs (only on Windows, Cygwin, MinGW)  
```

However, currently none of the above libraries are specified as dependencies.

For now, I'm just going to support `icu4c`. We can deal with supporting `homebrew/dupes/libiconv` later - but it might make sense to do that work upstream if Homebrew's interested.

This is to deal with the situation from https://travis-ci.org/Linuxbrew/linuxbrew/builds/118770388#L1125
> /home/travis/build/Linuxbrew/linuxbrew/bin/ld: warning: libicui18n.so.48, needed by /home/travis/build/Linuxbrew/linuxbrew/lib/libxerces-c.so, not found (try using -rpath or -rpath-link)