### PR TITLE
texinfo: Depends on ncurses for Linuxbrew

### DIFF
--- a/Library/Formula/texinfo.rb
+++ b/Library/Formula/texinfo.rb
@@ -17,6 +17,8 @@ class Texinfo < Formula
     of these files.
   EOS
 
+  depends_on "homebrew/dupes/ncurses" unless OS.mac?
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-install-warnings",


### PR DESCRIPTION
Fix the error:
```
..//info/makedoc ./session.c ./echo-area.c ./infodoc.c ./m-x.c ./indices.c ./nodemenu.c ./footnotes.c ./variables.c
..//info/makedoc: error while loading shared libraries: libncurses.so.5: cannot open shared object file: No such file or directory
make[1]: *** [funs.h] Error 127
```
https://gist.github.com/sjackman/79f8b79cc16eb4c7ba7f3ebb7a382717#file-02-make-L1186