### PR TITLE
postgresql: Depends on libxslt and util-linux for Linuxbrew

### DIFF
--- a/Library/Formula/postgresql.rb
+++ b/Library/Formula/postgresql.rb
@@ -12,7 +12,11 @@ class Postgresql < Formula
 
   option "32-bit"
   option "without-perl", "Build without Perl support"
-  option "without-tcl", "Build without Tcl support"
+  if OS.linux?
+    option "with-tcl", "Build with Tcl support"
+  else
+    option "without-tcl", "Build without Tcl support"
+  end
   option "with-dtrace", "Build with DTrace support"
 
   deprecated_option "no-perl" => "without-perl"
@@ -23,6 +27,9 @@ class Postgresql < Formula
   depends_on "readline"
   depends_on "libxml2" if MacOS.version <= :leopard # Leopard libxml is too old
   depends_on :python => :optional
+  depends_on "libxslt" unless OS.mac?
+  depends_on "util-linux" if OS.linux? # for libuuid
+  depends_on "homebrew/dupes/tcl-tk" if build.with?("tcl") && !OS.mac?
 
   conflicts_with "postgres-xc",
     :because => "postgresql and postgres-xc install the same binaries."


### PR DESCRIPTION
Without `libxslt`:
```
checking for xsltCleanupGlobals in -lxslt... no
configure: error: library 'xslt' is required for XSLT support
```

Without `libuuid`:
```
checking for uuid_generate in -luuid... no
configure: error: library 'uuid' is required for E2FS UUID
```

Closes Linuxbrew/linuxbrew#999

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?