### PR TITLE
re2: Fix for Linuxbrew

### DIFF
--- a/Library/Formula/re2.rb
+++ b/Library/Formula/re2.rb
@@ -16,11 +16,15 @@ class Re2 < Formula
     sha256 "941571b08e34921134c2fc15b5e855f7c2da5a882fd262766fa01dac988990f3" => :mavericks
   end
 
+  needs :cxx11 unless OS.mac?
+
   def install
+    ENV.cxx11 unless OS.mac?
     system "make", "install", "prefix=#{prefix}"
-    system "install_name_tool", "-id", "#{lib}/libre2.0.dylib", "#{lib}/libre2.0.0.0.dylib"
-    lib.install_symlink "libre2.0.0.0.dylib" => "libre2.0.dylib"
-    lib.install_symlink "libre2.0.0.0.dylib" => "libre2.dylib"
+    system "install_name_tool", "-id", "#{lib}/libre2.0.dylib", "#{lib}/libre2.0.0.0.dylib" if OS.mac?
+    ext = OS.mac? ? "dylib" : "so"
+    lib.install_symlink "libre2.0.0.0.#{ext}" => "libre2.0.#{ext}"
+    lib.install_symlink "libre2.0.0.0.#{ext}" => "libre2.#{ext}"
   end
 
   test do


### PR DESCRIPTION
There were two problems with `re2`:

1. It was installing libraries with the suffix ".dylib" instead of ".so".
2. It needs C++ 11. (On OS X it gets used by default).

From https://gist.github.com/rwhogg/83095a698e0ce3289c557c02ca1c0eb8#file-01-make-L11 :

```
In file included from util/hash.cc:41:
In file included from ./util/util.h:33:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/atomic:38:
/usr/bin/../lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/bits/c++0x_warning.h:32:2: error: This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
#error This file requires compiler and library support for the \
```

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?