### PR TITLE
Create xorg_requirement.rb

### DIFF
--- a/Library/Homebrew/dependency_collector.rb
+++ b/Library/Homebrew/dependency_collector.rb
@@ -94,7 +94,7 @@ class DependencyCollector
 
   def parse_symbol_spec(spec, tags)
     case spec
-    when :x11        then X11Requirement.new(spec.to_s, tags)
+    when :x11        then OS.mac? ? X11Requirement.new(spec.to_s, tags) : XorgRequirement.new(tags)
     when :xcode      then XcodeRequirement.new(tags)
     when :macos      then MinimumMacOSRequirement.new(tags)
     when :mysql      then MysqlRequirement.new(tags)

--- a/Library/Homebrew/os/mac/xquartz.rb
+++ b/Library/Homebrew/os/mac/xquartz.rb
@@ -30,7 +30,6 @@ module OS
       # The X11.app distributed by Apple is also XQuartz, and therefore covered
       # by this method.
       def version
-        @version ||= latest_version if OS.linux?
         @version ||= detect_version
       end
 
@@ -95,7 +94,6 @@ module OS
       # remain public. New code should use MacOS::X11.bin, MacOS::X11.lib and
       # MacOS::X11.include instead, as that accounts for Xcode-only systems.
       def prefix
-        @prefix ||= Pathname.new("/usr") if OS.linux?
         @prefix ||= if Pathname.new("/opt/X11/lib/libpng.dylib").exist?
           Pathname.new("/opt/X11")
         elsif Pathname.new("/usr/X11/lib/libpng.dylib").exist?

--- a/Library/Homebrew/requirements.rb
+++ b/Library/Homebrew/requirements.rb
@@ -12,6 +12,7 @@ require "requirements/ruby_requirement"
 require "requirements/tuntap_requirement"
 require "requirements/unsigned_kext_requirement"
 require "requirements/x11_requirement"
+require "requirements/xorg_requirement"
 require "requirements/emacs_requirement"
 require "requirements/glibc_requirement"
 

--- a/Library/Homebrew/requirements/x11_requirement.rb
+++ b/Library/Homebrew/requirements/x11_requirement.rb
@@ -1,5 +1,4 @@
 require "requirement"
-require "requirements/xorg_requirement" unless OS.mac?
 
 class X11Requirement < Requirement
   include Comparable

--- a/Library/Homebrew/requirements/x11_requirement.rb
+++ b/Library/Homebrew/requirements/x11_requirement.rb
@@ -1,4 +1,5 @@
 require "requirement"
+require "requirements/xorg_requirement" unless OS.mac?
 
 class X11Requirement < Requirement
   include Comparable
@@ -23,10 +24,15 @@ class X11Requirement < Requirement
   end
 
   satisfy :build_env => false do
-    MacOS::XQuartz.installed? && min_version <= Version.new(MacOS::XQuartz.version)
+    if OS.mac?
+      MacOS::XQuartz.installed? && min_version <= Version.new(MacOS::XQuartz.version)
+    else
+      XorgRequirement.new.satisfied?
+    end
   end
 
   def message
+    return XorgRequirement.new.message unless OS.mac?
     s = "XQuartz#{@min_version_string} is required to install this formula."
     s += super
     s

--- a/Library/Homebrew/requirements/xorg_requirement.rb
+++ b/Library/Homebrew/requirements/xorg_requirement.rb
@@ -1,0 +1,23 @@
+require "requirement"
+
+class XorgRequirement < Requirement
+  fatal true
+  default_formula "linuxbrew/xorg/xorg"
+
+  env { ENV.x11 }
+
+  def initialize(name = "xorg", tags = [])
+    @name = name
+    super(tags)
+  end
+
+  satisfy :build_env => false do
+    Formula["linuxbrew/xorg/xorg"].installed?
+  end
+
+  def message
+    s = "X.Org is required to install this formula."
+    s += super
+    s
+  end
+end

--- a/Library/Homebrew/requirements/xorg_requirement.rb
+++ b/Library/Homebrew/requirements/xorg_requirement.rb
@@ -1,6 +1,7 @@
 require "requirement"
+require "requirements/x11_requirement"
 
-class XorgRequirement < Requirement
+class XorgRequirement < X11Requirement
   fatal true
   default_formula "linuxbrew/xorg/xorg"
 
@@ -16,8 +17,6 @@ class XorgRequirement < Requirement
   end
 
   def message
-    s = "X.Org is required to install this formula."
-    s += super
-    s
+    "X.Org is required to install this formula."
   end
 end


### PR DESCRIPTION
This creates a new `XorgRequirement` class and hacks `X11Requirement` to defer to it as necessary.
It also removes some hackery from xquartz.rb that just pretended X11 was already installed.

Closes Linuxbrew/linuxbrew#951

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable? [Here's an example](https://github.com/Homebrew/homebrew/pull/49031) if you'd like one.
- [ ] Have you successfully ran `brew tests` with your changes locally?