### PR TITLE
cmake: fix https support in linux by using system curl

### DIFF
--- a/Library/Formula/cmake.rb
+++ b/Library/Formula/cmake.rb
@@ -4,6 +4,7 @@ class Cmake < Formula
   url "https://cmake.org/files/v3.5/cmake-3.5.1.tar.gz"
   sha256 "93d651a754bcf6f0124669646391dd5774c0fc4d407c384e3ae76ef9a60477e8"
   head "https://cmake.org/cmake.git"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation
@@ -37,7 +38,7 @@ class Cmake < Formula
     ]
 
     # https://github.com/Homebrew/homebrew/issues/45989
-    if MacOS.version <= :lion
+    if OS.mac? and MacOS.version <= :lion
       args << "--no-system-curl"
     else
       args << "--system-curl"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

## Changes
It's right to have cmake depend on curl on Linux, but the if/else block that disables system curl on old OS X versions was actually firing for Linux as well. The symptom is that all ExternalProject_Add() calls that used a https url failed to work.

This includes a revision bump because the bottle needs to be rebuilt to link against the linuxbrew curl (and OpenSSL). I assume that's right?