### PR TITLE
git: Fix Error: Directory not empty

### DIFF
--- a/Library/Formula/git.rb
+++ b/Library/Formula/git.rb
@@ -155,9 +155,7 @@ class Git < Formula
     if pod != nil
       # Remove perllocal.pod, which conflicts with the perl formula.
       # I don't know why this issue doesn't affect Mac.
-      pod = Pathname.new pod
-      rm pod
-      rmdir [pod.dirname, pod.dirname.dirname]
+      rm_r Pathname.new(pod).dirname.dirname
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/linuxbrew/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/linuxbrew/pulls) for the same update/change?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

## Changes

On some systems the install of the htmldocs resource would fail because of a directory removal call on a directory that was non-empty. This fixes issue #1063.